### PR TITLE
Phantom methods are skipped now as sanitizers during query execution.

### DIFF
--- a/de.fraunhofer.iem.secucheck.analysis/src/main/java/de/fraunhofer/iem/secucheck/analysis/internal/SingleFlowAnalysis.java
+++ b/de.fraunhofer.iem.secucheck.analysis/src/main/java/de/fraunhofer/iem/secucheck/analysis/internal/SingleFlowAnalysis.java
@@ -294,7 +294,7 @@ class SingleFlowAnalysis implements Analysis {
 		
 		for (Method method : methods) {
 			SootMethod sootMethod = Utility.getSootMethod(method);
-			if (sootMethod != null) {
+			if (sootMethod != null && !sootMethod.isPhantom()) {
 				Body body = sootMethod.getActiveBody();
 				if (body != null) {
 					oldBodies.put(sootMethod, body);


### PR DESCRIPTION
Phantom methods are skipped now as sanitizers during query execution.